### PR TITLE
Update edge executor data types and tree builder for edge-enriched missions

### DIFF
--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -27,6 +27,7 @@ from typing import Dict
 from typing import List
 from typing import Union
 from typing import Callable
+from .datatypes import Edge
 
 from async_timeout import timeout
 
@@ -562,6 +563,7 @@ class RunActionNode(BehaviorTree):
         target: Target = None,
         max_retries: int = 3,
         retry_wait_seconds: float = 5.0,
+        edge: Edge = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -575,6 +577,7 @@ class RunActionNode(BehaviorTree):
             self.robot = context.robot_api
         else:
             self.robot = context.robot_api_factory.build(self.target.robot_id)
+        self.edge = edge
 
     async def _execute(self):
         arguments = await self.mt.resolve_arguments(self.arguments)
@@ -615,6 +618,8 @@ class RunActionNode(BehaviorTree):
         object["retry_wait_seconds"] = self.retry_wait_seconds
         if self.target is not None:
             object["target"] = self.target.dump_object()
+        if self.edge is not None:
+            object["edge"] = self.edge.model_dump()
         return object
 
     @classmethod
@@ -626,12 +631,15 @@ class RunActionNode(BehaviorTree):
         target=None,
         max_retries=3,
         retry_wait_seconds=5.0,
+        edge=None,
         **kwargs,
     ):
         if target is not None:
             target = Target.from_object(**target)
+        if edge is not None:
+            edge = Edge.model_validate(edge)
         return RunActionNode(
-            context, action_id, arguments, target, max_retries, retry_wait_seconds, **kwargs
+            context, action_id, arguments, target, max_retries, retry_wait_seconds, edge, **kwargs
         )
 
 
@@ -1159,6 +1167,7 @@ class NodeFromStepBuilder:
                 )
             ),
             label=step.label,
+            edge=step.edge if step.edge else None,
         )
         expr = f"pose = getValue('pose'); theta = pose.theta; pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance} and abs(angularDistance(theta, {waypoint.theta})) < {self.waypoint_angular_tolerance}"
         wait_node = WaitExpressionNode(

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -619,7 +619,7 @@ class RunActionNode(BehaviorTree):
         if self.target is not None:
             object["target"] = self.target.dump_object()
         if self.edge is not None:
-            object["edge"] = self.edge.model_dump()
+            object["edge"] = self.edge.model_dump(by_alias=True)
         return object
 
     @classmethod

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -1154,7 +1154,7 @@ class NodeFromStepBuilder:
                 theta=waypoint.theta,
                 frameId=waypoint.frame_id,
             ),
-            **({"routeSegment": step.routeSegment.model_dump()} if step.routeSegment else {})
+            **({"routeSegment": step.routeSegment.model_dump()} if step.routeSegment else {}),
         )
         go_node = RunActionNode(
             context=self.context,

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -1163,7 +1163,10 @@ class NodeFromStepBuilder:
             arguments=arguments,
             label=step.label,
         )
-        expr = f"pose = getValue('pose'); theta = pose.theta; pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance} and abs(angularDistance(theta, {waypoint.theta})) < {self.waypoint_angular_tolerance}"
+        if waypoint.theta is not None:
+            expr = f"pose = getValue('pose'); theta = pose.theta; pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance} and abs(angularDistance(theta, {waypoint.theta})) < {self.waypoint_angular_tolerance}"
+        else:
+            expr = f"pose = getValue('pose'); pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance}"
         wait_node = WaitExpressionNode(
             self.context,
             expr,

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -1154,9 +1154,8 @@ class NodeFromStepBuilder:
                 theta=waypoint.theta,
                 frameId=waypoint.frame_id,
             ),
+            **({"routeSegment": step.routeSegment.model_dump()} if step.routeSegment else {})
         )
-        if step.routeSegment:
-            arguments["routeSegment"] = step.routeSegment.model_dump()
         go_node = RunActionNode(
             context=self.context,
             action_id=ACTION_NAVIGATE_TO_ID,

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -27,7 +27,6 @@ from typing import Dict
 from typing import List
 from typing import Union
 from typing import Callable
-from .datatypes import Edge
 
 from async_timeout import timeout
 
@@ -563,7 +562,6 @@ class RunActionNode(BehaviorTree):
         target: Target = None,
         max_retries: int = 3,
         retry_wait_seconds: float = 5.0,
-        edge: Edge = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -577,7 +575,6 @@ class RunActionNode(BehaviorTree):
             self.robot = context.robot_api
         else:
             self.robot = context.robot_api_factory.build(self.target.robot_id)
-        self.edge = edge
 
     async def _execute(self):
         arguments = await self.mt.resolve_arguments(self.arguments)
@@ -618,8 +615,6 @@ class RunActionNode(BehaviorTree):
         object["retry_wait_seconds"] = self.retry_wait_seconds
         if self.target is not None:
             object["target"] = self.target.dump_object()
-        if self.edge is not None:
-            object["edge"] = self.edge.model_dump(by_alias=True)
         return object
 
     @classmethod
@@ -631,15 +626,12 @@ class RunActionNode(BehaviorTree):
         target=None,
         max_retries=3,
         retry_wait_seconds=5.0,
-        edge=None,
         **kwargs,
     ):
         if target is not None:
             target = Target.from_object(**target)
-        if edge is not None:
-            edge = Edge.model_validate(edge)
         return RunActionNode(
-            context, action_id, arguments, target, max_retries, retry_wait_seconds, edge, **kwargs
+            context, action_id, arguments, target, max_retries, retry_wait_seconds, **kwargs
         )
 
 
@@ -1155,19 +1147,21 @@ class NodeFromStepBuilder:
 
     def visit_pose_waypoint(self, step: MissionStepPoseWaypoint):
         waypoint = step.waypoint
+        arguments = dict(
+            pose=dict(
+                x=waypoint.x,
+                y=waypoint.y,
+                theta=waypoint.theta,
+                frameId=waypoint.frame_id,
+            ),
+        )
+        if step.routeSegment:
+            arguments["routeSegment"] = step.routeSegment.model_dump()
         go_node = RunActionNode(
             context=self.context,
             action_id=ACTION_NAVIGATE_TO_ID,
-            arguments=dict(
-                pose=dict(
-                    x=waypoint.x,
-                    y=waypoint.y,
-                    theta=waypoint.theta,
-                    frameId=waypoint.frame_id,
-                )
-            ),
+            arguments=arguments,
             label=step.label,
-            edge=step.routeSegment if step.routeSegment else None,
         )
         expr = f"pose = getValue('pose'); theta = pose.theta; pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance} and abs(angularDistance(theta, {waypoint.theta})) < {self.waypoint_angular_tolerance}"
         wait_node = WaitExpressionNode(

--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -1167,7 +1167,7 @@ class NodeFromStepBuilder:
                 )
             ),
             label=step.label,
-            edge=step.edge if step.edge else None,
+            edge=step.routeSegment if step.routeSegment else None,
         )
         expr = f"pose = getValue('pose'); theta = pose.theta; pose and pose.frameId == '{waypoint.frame_id}' and sqrt(pow(pose.x-{waypoint.x}, 2) + pow(pose.y-{waypoint.y}, 2)) < {self.waypoint_distance_tolerance} and abs(angularDistance(theta, {waypoint.theta})) < {self.waypoint_angular_tolerance}"
         wait_node = WaitExpressionNode(

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -143,7 +143,6 @@ class MissionStepPoseWaypoint(MissionStep):
     Note that like MissionStepNamedWaypoint, both are represented with a 'waypoint' field
     """
 
-    model_config = ConfigDict(extra="allow")
     waypoint: Pose
     routeSegment: Optional[RouteSegment] = Field(default=None)
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -107,12 +107,13 @@ class MissionStepSetData(MissionStep):
         return MissionStepTypes.SET_DATA.value
 
 
-class EdgeTrajectoryNurbsParameters(BaseModel):
+class RouteSegmentTrajectoryNurbsParameters(BaseModel):
     degree: int
     knotVector: List[float]
     controlPoints: List[Dict[str, float]]
 
-class EdgeCorridor(BaseModel):
+
+class RouteSegmentCorridor(BaseModel):
     width: Optional[float] = Field(default=None)
     rightWidth: Optional[float] = Field(default=None)
     leftWidth: Optional[float] = Field(default=None)
@@ -121,7 +122,9 @@ class EdgeCorridor(BaseModel):
     def validate(self):
         if self.leftWidth is not None and self.rightWidth is not None:
             if self.width is not None:
-                raise ValueError("width cannot be specified if leftWidth and rightWidth are provided")
+                raise ValueError(
+                    "width cannot be specified if leftWidth and rightWidth are provided"
+                )
         if (self.leftWidth is not None) != (self.rightWidth is not None):
             raise ValueError("you have to specify both leftWidth and rightWidth")
         if self.width is None and self.leftWidth is None and self.rightWidth is None:
@@ -129,10 +132,10 @@ class EdgeCorridor(BaseModel):
         return self
 
 
-class Edge(BaseModel):
+class RouteSegment(BaseModel):
     routeId: str
-    trajectory: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
-    corridor: Optional[EdgeCorridor] = Field(default=None)
+    trajectory: Optional[RouteSegmentTrajectoryNurbsParameters] = Field(default=None)
+    corridor: Optional[RouteSegmentCorridor] = Field(default=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 
 
@@ -145,7 +148,7 @@ class MissionStepPoseWaypoint(MissionStep):
 
     model_config = ConfigDict(extra="allow")
     waypoint: Pose
-    routeSegment: Optional[Edge] = Field(default=None)
+    routeSegment: Optional[RouteSegment] = Field(default=None)
 
     def accept(self, visitor):
         return visitor.visit_pose_waypoint(self)

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -128,9 +128,18 @@ class EdgeTrajectory(BaseModel):
         return self
 
 
+class EdgeCorridor(BaseModel):
+    width: float
+
+
 class Edge(BaseModel):
+    edge_id: Optional[str] = Field(alias="edgeId", default=None)
+    start_waypoint_id: Optional[str] = Field(alias="startWaypointId", default=None)
+    end_waypoint_id: Optional[str] = Field(alias="endWaypointId", default=None)
+    bidirectional: Optional[bool] = Field(default=None)
     trajectory: Optional[EdgeTrajectory] = Field(default=None)
-    properties: Optional[Dict[str, Optional[str]]] = Field(default=None)
+    corridor: Optional[EdgeCorridor] = Field(default=None)
+    properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 
 
 class MissionStepPoseWaypoint(MissionStep):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -150,7 +150,7 @@ class MissionStepPoseWaypoint(MissionStep):
     """
     model_config = ConfigDict(extra="allow")
     waypoint: Pose
-    edge: Optional[Edge] = Field(default=None)
+    routeSegment: Optional[Edge] = Field(default=None)
 
     def accept(self, visitor):
         return visitor.visit_pose_waypoint(self)

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -122,7 +122,7 @@ class RouteSegmentCorridor(BaseModel):
     def validate(self):
         if all([self.leftWidth, self.rightWidth, self.width]):
                 raise ValueError(
-                    "width cannot be specified if leftWidth and rightWidth are provided"
+                    "width should be none if leftWidth and rightWidth are provided"
                 )
         if (self.leftWidth is not None) != (self.rightWidth is not None):
             raise ValueError("you have to specify both leftWidth and rightWidth")

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -269,7 +269,7 @@ class MissionDefinition(BaseModel):
     selector: Any = Field(
         default=None
     )  # Accepted from API just to complete schema in struct mode (and ignore the field)
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class MissionTask(BaseModel):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -112,7 +112,6 @@ class EdgeTrajectoryNurbsParameters(BaseModel):
     controlPoints: List[Dict[str, float]]
 
 
-
 class EdgeCorridor(BaseModel):
     width: float
 
@@ -120,7 +119,7 @@ class EdgeCorridor(BaseModel):
 class Edge(BaseModel):
     routeId: str
     trajectory: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
-    corridor: Optional[EdgeCorridor]= Field(default=None)
+    corridor: Optional[EdgeCorridor] = Field(default=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 
 
@@ -130,13 +129,14 @@ class MissionStepPoseWaypoint(MissionStep):
 
     Note that like MissionStepNamedWaypoint, both are represented with a 'waypoint' field
     """
+
     model_config = ConfigDict(extra="allow")
     waypoint: Pose
     routeSegment: Optional[Edge] = Field(default=None)
 
     def accept(self, visitor):
         return visitor.visit_pose_waypoint(self)
-    
+
     def get_type(self):
         return MissionStepTypes.POSE_WAYPOINT.value
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -120,14 +120,13 @@ class RouteSegmentCorridor(BaseModel):
 
     @model_validator(mode="after")
     def validate(self):
-        if self.leftWidth is not None and self.rightWidth is not None:
-            if self.width is not None:
+        if all([self.leftWidth, self.rightWidth, self.width]):
                 raise ValueError(
                     "width cannot be specified if leftWidth and rightWidth are provided"
                 )
         if (self.leftWidth is not None) != (self.rightWidth is not None):
             raise ValueError("you have to specify both leftWidth and rightWidth")
-        if self.width is None and self.leftWidth is None and self.rightWidth is None:
+        if not any([self.leftWidth, self.rightWidth, self.width]):
             raise ValueError("you have to specify either width or both leftWidth and rightWidth")
         return self
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -33,6 +33,8 @@ class MissionStepTypes(Enum):
     POSE_WAYPOINT = "poseWaypoint"
     IF = "if"
 
+class TrajectoryTypes(Enum):
+    NURBS = "nurbs"
 
 class Robot(BaseModel):
     id: str  # InOrbit robot id
@@ -113,6 +115,17 @@ class RouteSegmentTrajectoryNurbsParameters(BaseModel):
     controlPoints: List[Dict[str, float]]
 
 
+class RouteSegmentTrajectory(BaseModel):
+    type: Optional[TrajectoryTypes] = Field(default=None)
+    parameters: Optional[RouteSegmentTrajectoryNurbsParameters] = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate(self):
+        if self.type == TrajectoryTypes.NURBS and self.parameters is None:
+            raise ValueError("parameters are required when type is nurbs")
+        return self
+
+
 class RouteSegmentCorridor(BaseModel):
     width: Optional[float] = Field(default=None)
     rightWidth: Optional[float] = Field(default=None)
@@ -131,7 +144,7 @@ class RouteSegmentCorridor(BaseModel):
 
 class RouteSegment(BaseModel):
     routeId: str
-    trajectory: Optional[RouteSegmentTrajectoryNurbsParameters] = Field(default=None)
+    trajectory: Optional[RouteSegmentTrajectory] = Field(default=None)
     corridor: Optional[RouteSegmentCorridor] = Field(default=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -134,8 +134,8 @@ class EdgeCorridor(BaseModel):
 
 class Edge(BaseModel):
     routeId: str
-    trajectory: Optional[EdgeTrajectory] = Field(default=None)
-    corridor: Optional[EdgeCorridor] = Field(default=None)
+    trajectory: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
+    corridor: Optional[EdgeCorridor] = Field(type=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -33,8 +33,10 @@ class MissionStepTypes(Enum):
     POSE_WAYPOINT = "poseWaypoint"
     IF = "if"
 
+
 class TrajectoryTypes(Enum):
     NURBS = "nurbs"
+
 
 class Robot(BaseModel):
     id: str  # InOrbit robot id

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -44,7 +44,7 @@ class Pose(BaseModel):
 
     x: float
     y: float
-    theta: float
+    theta: Optional[float] = Field(default=None)
     frame_id: Optional[str] = Field(alias="frameId", default=None)
     waypointId: str = Field(alias="waypointId", default=None)
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -13,6 +13,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+from pydantic import model_validator
+
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -107,15 +109,43 @@ class MissionStepSetData(MissionStep):
         return MissionStepTypes.SET_DATA.value
 
 
+class EdgeTrajectoryNurbsParameters(BaseModel):
+    degree: int
+    knotVector: List[float]
+    controlPoints: List[Dict[str, float]]
+
+
+class EdgeTrajectory(BaseModel):
+    type: str  # "nurbs" or "line"
+    parameters: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_parameters(self):
+        if self.type == "nurbs" and self.parameters is None:
+            raise ValueError("NURBS trajectory requires parameters")
+        if self.type != "nurbs" and self.parameters is not None:
+            raise ValueError(f'Trajectory type "{self.type}" must not include parameters')
+        return self
+
+
+class Edge(BaseModel):
+    trajectory: Optional[EdgeTrajectory] = Field(default=None)
+    properties: Optional[Dict[str, Optional[str]]] = Field(default=None)
+
+
 class MissionStepPoseWaypoint(MissionStep):
     """
     Mission step for navigating to a named waypoint.
 
     Note that like MissionStepNamedWaypoint, both are represented with a 'waypoint' field
     """
-
+    model_config = ConfigDict(extra="allow")
     waypoint: Pose
+    edge: Optional[Edge] = Field(default=None)
 
+    def accept(self, visitor):
+        return visitor.visit_pose_waypoint(self)
+    
     def get_type(self):
         return MissionStepTypes.POSE_WAYPOINT.value
 
@@ -251,7 +281,7 @@ class MissionDefinition(BaseModel):
     selector: Any = Field(
         default=None
     )  # Accepted from API just to complete schema in struct mode (and ignore the field)
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
 
 
 class MissionTask(BaseModel):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -13,9 +13,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
-from pydantic import model_validator
-
-
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
@@ -114,18 +111,6 @@ class EdgeTrajectoryNurbsParameters(BaseModel):
     knotVector: List[float]
     controlPoints: List[Dict[str, float]]
 
-
-class EdgeTrajectory(BaseModel):
-    type: str  # "nurbs" or "line"
-    parameters: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
-
-    @model_validator(mode="after")
-    def validate_parameters(self):
-        if self.type == "nurbs" and self.parameters is None:
-            raise ValueError("NURBS trajectory requires parameters")
-        if self.type != "nurbs" and self.parameters is not None:
-            raise ValueError(f'Trajectory type "{self.type}" must not include parameters')
-        return self
 
 
 class EdgeCorridor(BaseModel):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -285,6 +285,7 @@ class MissionDefinition(BaseModel):
     selector: Any = Field(
         default=None
     )  # Accepted from API just to complete schema in struct mode (and ignore the field)
+    planner: Any = Field(default=None)
     model_config = ConfigDict(extra="forbid")
 
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -16,6 +16,7 @@ from typing import Union
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import model_validator
 
 
 class MissionTrackingTypes(Enum):
@@ -111,9 +112,21 @@ class EdgeTrajectoryNurbsParameters(BaseModel):
     knotVector: List[float]
     controlPoints: List[Dict[str, float]]
 
-
 class EdgeCorridor(BaseModel):
-    width: float
+    width: Optional[float] = Field(default=None)
+    rightWidth: Optional[float] = Field(default=None)
+    leftWidth: Optional[float] = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate(self):
+        if self.leftWidth is not None and self.rightWidth is not None:
+            if self.width is not None:
+                raise ValueError("width cannot be specified if leftWidth and rightWidth are provided")
+        if (self.leftWidth is not None) != (self.rightWidth is not None):
+            raise ValueError("you have to specify both leftWidth and rightWidth")
+        if self.width is None and self.leftWidth is None and self.rightWidth is None:
+            raise ValueError("you have to specify either width or both leftWidth and rightWidth")
+        return self
 
 
 class Edge(BaseModel):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -133,10 +133,7 @@ class EdgeCorridor(BaseModel):
 
 
 class Edge(BaseModel):
-    edge_id: Optional[str] = Field(alias="edgeId", default=None)
-    start_waypoint_id: Optional[str] = Field(alias="startWaypointId", default=None)
-    end_waypoint_id: Optional[str] = Field(alias="endWaypointId", default=None)
-    bidirectional: Optional[bool] = Field(default=None)
+    routeId: str
     trajectory: Optional[EdgeTrajectory] = Field(default=None)
     corridor: Optional[EdgeCorridor] = Field(default=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -121,9 +121,7 @@ class RouteSegmentCorridor(BaseModel):
     @model_validator(mode="after")
     def validate(self):
         if all([self.leftWidth, self.rightWidth, self.width]):
-                raise ValueError(
-                    "width should be none if leftWidth and rightWidth are provided"
-                )
+            raise ValueError("width should be none if leftWidth and rightWidth are provided")
         if (self.leftWidth is not None) != (self.rightWidth is not None):
             raise ValueError("you have to specify both leftWidth and rightWidth")
         if not any([self.leftWidth, self.rightWidth, self.width]):

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -135,7 +135,7 @@ class EdgeCorridor(BaseModel):
 class Edge(BaseModel):
     routeId: str
     trajectory: Optional[EdgeTrajectoryNurbsParameters] = Field(default=None)
-    corridor: Optional[EdgeCorridor] = Field(type=None)
+    corridor: Optional[EdgeCorridor]= Field(default=None)
     properties: Optional[Dict[str, Dict[str, Optional[str]]]] = Field(default=None)
 
 

--- a/inorbit_edge_executor/datatypes.py
+++ b/inorbit_edge_executor/datatypes.py
@@ -158,9 +158,6 @@ class MissionStepPoseWaypoint(MissionStep):
     def get_type(self):
         return MissionStepTypes.POSE_WAYPOINT.value
 
-    def accept(self, visitor):
-        return visitor.visit_pose_waypoint(self)
-
 
 class MissionStepWaitUntil(MissionStep):
     """

--- a/inorbit_edge_executor/worker_pool.py
+++ b/inorbit_edge_executor/worker_pool.py
@@ -30,6 +30,8 @@ from .inorbit import InOrbitAPI, MissionStatus, MissionTrackingAPI, RobotApiFact
 from .logger import setup_logger
 from .mission import Mission
 from .worker import Worker
+from .datatypes import MissionStep
+
 
 logger = setup_logger(name="WorkerPool")
 
@@ -242,19 +244,33 @@ class WorkerPool:
         else:
             context.mt = MissionTrackingAPI(mission, self._api)
 
-    def translate_mission(self, mission: Mission):
+    def translate_mission(self, mission: Mission) -> Mission:
+
         """
         Performs any necessary translation from a mission (from its definition coming
         from InOrbit) to one that the current connector can execute.
 
-        For example, connectors may merge two "visit waypoint" into one "navigate from
-        waypoint A to waypoint B" step, if that's how the robot or fleet manager works.
+        By default, iterates over all steps and calls translate_step() on each one.
+ 
+        Connectors that need cross-step logic should override this method entirely instead.
 
-        The resulting MissionDefinition can then include non-standard MissionSteps.
-
-        By default it does nothing; simply returns the same mission.
+        The resulting MissionDefinition can include non-standard MissionSteps.
         """
+        mission.definition.steps = [
+            self.translate_step(step) for step in mission.definition.steps
+        ]
         return mission
+
+    def translate_step(self, step: MissionStep) -> MissionStep:
+        """
+        Translates a single mission step. 
+
+        Override this in connector subclasses to transform individual steps without
+        having to iterate over the mission manually.
+
+        By default returns the step unchanged.
+        """
+        return step
 
     async def submit_work(
         self,

--- a/inorbit_edge_executor/worker_pool.py
+++ b/inorbit_edge_executor/worker_pool.py
@@ -32,7 +32,6 @@ from .mission import Mission
 from .worker import Worker
 from .datatypes import MissionStep
 
-
 logger = setup_logger(name="WorkerPool")
 
 
@@ -245,25 +244,22 @@ class WorkerPool:
             context.mt = MissionTrackingAPI(mission, self._api)
 
     def translate_mission(self, mission: Mission) -> Mission:
-
         """
         Performs any necessary translation from a mission (from its definition coming
         from InOrbit) to one that the current connector can execute.
 
         By default, iterates over all steps and calls translate_step() on each one.
- 
+
         Connectors that need cross-step logic should override this method entirely instead.
 
         The resulting MissionDefinition can include non-standard MissionSteps.
         """
-        mission.definition.steps = [
-            self.translate_step(step) for step in mission.definition.steps
-        ]
+        mission.definition.steps = [self.translate_step(step) for step in mission.definition.steps]
         return mission
 
     def translate_step(self, step: MissionStep) -> MissionStep:
         """
-        Translates a single mission step. 
+        Translates a single mission step.
 
         Override this in connector subclasses to transform individual steps without
         having to iterate over the mission manually.

--- a/tests/test_behavior_tree.py
+++ b/tests/test_behavior_tree.py
@@ -13,6 +13,7 @@ from inorbit_edge_executor.dummy_backend import DummyDB
 from inorbit_edge_executor.inorbit import InOrbitAPI
 from inorbit_edge_executor.inorbit import RobotApiFactory
 from inorbit_edge_executor.mission import Mission
+from inorbit_edge_executor.worker_pool import WorkerPool
 
 logger = getLogger("test-bt")
 
@@ -354,3 +355,62 @@ def test_bt_if_with_target():
     assert step_node["type"] == "IfNode"
     assert step_node["expression"] == "getValue('battery') > 50"
     assert step_node["target"]["robot_id"] == "robot456"
+
+
+def _build_waypoint_nodes(step_dict):
+    """Helper: build a tree with a single PoseWaypoint step and return (run_action_node, wait_node)."""
+    mission = Mission(
+        id="mission123",
+        robot_id="robot123",
+        definition=MissionDefinition(label="A mission", steps=[step_dict]),
+    )
+    context = BehaviorTreeBuilderContext()
+    context.mission = mission
+    context.options = MissionRuntimeOptions()
+    context.shared_memory = MissionRuntimeSharedMemory()
+    tree_obj = DefaultTreeBuilder().build_tree_for_mission(context).dump_object()
+    mission_sequential = tree_obj["children"][0]
+    step_wrap = mission_sequential["children"][1]
+    error_handler = step_wrap["children"][1]
+    waypoint_seq = error_handler["children"][0]
+    return waypoint_seq["children"][0], waypoint_seq["children"][1]
+
+
+def test_visit_pose_waypoint_route_segment_in_arguments():
+    run_node, _ = _build_waypoint_nodes(
+        {
+            "waypoint": {"x": 1.0, "y": 2.0, "theta": 0.0, "frameId": "map"},
+            "routeSegment": {"routeId": "route-1", "corridor": {"width": 1.5}},
+        }
+    )
+    assert "routeSegment" in run_node["arguments"]
+    assert run_node["arguments"]["routeSegment"]["routeId"] == "route-1"
+
+
+def test_visit_pose_waypoint_no_route_segment_excluded_from_arguments():
+    run_node, _ = _build_waypoint_nodes(
+        {"waypoint": {"x": 1.0, "y": 2.0, "theta": 0.0, "frameId": "map"}}
+    )
+    assert "routeSegment" not in run_node["arguments"]
+
+
+def test_visit_pose_waypoint_theta_none_skips_angular_distance():
+    _, wait_node = _build_waypoint_nodes({"waypoint": {"x": 1.0, "y": 2.0, "frameId": "map"}})
+    assert "angularDistance" not in wait_node["expression"]
+
+
+def test_visit_pose_waypoint_theta_set_includes_angular_distance():
+    _, wait_node = _build_waypoint_nodes(
+        {"waypoint": {"x": 1.0, "y": 2.0, "theta": 1.57, "frameId": "map"}}
+    )
+    assert "angularDistance" in wait_node["expression"]
+
+
+def test_translate_step_default_returns_step_unchanged(inorbit_api):
+    from inorbit_edge_executor.datatypes import MissionStepPoseWaypoint
+
+    worker_pool = WorkerPool(db=None, api=inorbit_api, behavior_tree_builder=DefaultTreeBuilder())
+    step = MissionStepPoseWaypoint.model_validate(
+        {"waypoint": {"x": 0.0, "y": 0.0, "theta": 0.0, "frameId": "map"}}
+    )
+    assert worker_pool.translate_step(step) is step

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -11,6 +11,7 @@ from inorbit_edge_executor.datatypes import (
     RouteSegmentTrajectoryNurbsParameters,
     MissionDefinition,
     MissionStepPoseWaypoint,
+    Pose,
 )
 
 # ---------------------------------------------------------------------------
@@ -248,6 +249,40 @@ def test_mission_definition_with_route_segment_step():
     assert isinstance(second, MissionStepPoseWaypoint)
     assert second.routeSegment.routeId == "route-start-end"
     assert second.routeSegment.corridor.width == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Pose — optional theta
+# ---------------------------------------------------------------------------
+
+
+def test_pose_theta_optional():
+    pose = Pose(x=1.0, y=2.0, frameId="map")
+    assert pose.theta is None
+
+
+def test_pose_theta_when_provided():
+    pose = Pose(x=1.0, y=2.0, theta=1.57, frameId="map")
+    assert pose.theta == 1.57
+
+
+# ---------------------------------------------------------------------------
+# MissionDefinition — planner field
+# ---------------------------------------------------------------------------
+
+
+def test_mission_definition_accepts_planner_field():
+    definition = MissionDefinition(
+        label="test",
+        steps=[],
+        planner={"type": "graph", "options": {"allowFreePlanning": False}},
+    )
+    assert definition.planner == {"type": "graph", "options": {"allowFreePlanning": False}}
+
+
+def test_mission_definition_planner_defaults_to_none():
+    definition = MissionDefinition(label="test", steps=[])
+    assert definition.planner is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -6,35 +6,35 @@ import pytest
 from pydantic import ValidationError
 
 from inorbit_edge_executor.datatypes import (
-    Edge,
-    EdgeCorridor,
-    EdgeTrajectoryNurbsParameters,
+    RouteSegment,
+    RouteSegmentCorridor,
+    RouteSegmentTrajectoryNurbsParameters,
     MissionDefinition,
     MissionStepPoseWaypoint,
 )
 
 # ---------------------------------------------------------------------------
-# EdgeCorridor
+# RouteSegmentCorridor
 # ---------------------------------------------------------------------------
 
 
 def test_edge_corridor_basic():
-    corridor = EdgeCorridor(width=2.0)
+    corridor = RouteSegmentCorridor(width=2.0)
     assert corridor.width == 2.0
 
 
 def test_edge_corridor_requires_width():
     with pytest.raises(ValidationError):
-        EdgeCorridor()
+        RouteSegmentCorridor()
 
 
 # ---------------------------------------------------------------------------
-# Edge — field presence
+# RouteSegment — field presence
 # ---------------------------------------------------------------------------
 
 
 def test_edge_all_fields():
-    edge = Edge(
+    route_segment = RouteSegment(
         **{
             "routeId": "route-AB",
             "trajectory": {
@@ -50,39 +50,39 @@ def test_edge_all_fields():
             "properties": {"routeSegment": {"maxSpeed": "2"}},
         }
     )
-    assert edge.routeId == "route-AB"
-    assert edge.trajectory.degree == 3
-    assert edge.corridor.width == 2.0
-    assert edge.properties == {"routeSegment": {"maxSpeed": "2"}}
+    assert route_segment.routeId == "route-AB"
+    assert route_segment.trajectory.degree == 3
+    assert route_segment.corridor.width == 2.0
+    assert route_segment.properties == {"routeSegment": {"maxSpeed": "2"}}
 
 
 def test_edge_optional_fields_default_to_none():
-    edge = Edge(routeId="route-1")
-    assert edge.trajectory is None
-    assert edge.corridor is None
-    assert edge.properties is None
+    route_segment = RouteSegment(routeId="route-1")
+    assert route_segment.trajectory is None
+    assert route_segment.corridor is None
+    assert route_segment.properties is None
 
 
 def test_edge_partial_fields():
-    edge = Edge(**{"routeId": "route-XY", "corridor": {"width": 1.5}})
-    assert edge.routeId == "route-XY"
-    assert edge.corridor.width == 1.5
-    assert edge.trajectory is None
-    assert edge.properties is None
+    route_segment = RouteSegment(**{"routeId": "route-XY", "corridor": {"width": 1.5}})
+    assert route_segment.routeId == "route-XY"
+    assert route_segment.corridor.width == 1.5
+    assert route_segment.trajectory is None
+    assert route_segment.properties is None
 
 
 def test_edge_requires_route_id():
     with pytest.raises(ValidationError):
-        Edge()
+        RouteSegment()
 
 
 # ---------------------------------------------------------------------------
-# Edge — properties shape
+# RouteSegment — properties shape
 # ---------------------------------------------------------------------------
 
 
 def test_edge_properties_nested_dict():
-    edge = Edge(
+    route_segment = RouteSegment(
         **{
             "routeId": "route-1",
             "properties": {
@@ -90,28 +90,28 @@ def test_edge_properties_nested_dict():
             },
         }
     )
-    assert edge.properties["routeSegment"]["maxSpeed"] == "2"
-    assert edge.properties["routeSegment"]["someOtherProp"] == "value"
-    assert edge.properties["routeSegment"]["nullableProp"] is None
+    assert route_segment.properties["routeSegment"]["maxSpeed"] == "2"
+    assert route_segment.properties["routeSegment"]["someOtherProp"] == "value"
+    assert route_segment.properties["routeSegment"]["nullableProp"] is None
 
 
 def test_edge_properties_flat_dict_is_invalid():
     with pytest.raises(ValidationError):
-        Edge(**{"routeId": "route-1", "properties": {"maxSpeed": "2"}})
+        RouteSegment(**{"routeId": "route-1", "properties": {"maxSpeed": "2"}})
 
 
 # ---------------------------------------------------------------------------
-# Edge — trajectory
+# RouteSegment — trajectory
 # ---------------------------------------------------------------------------
 
 
 def test_edge_trajectory_null_means_straight_line():
-    edge = Edge(**{"routeId": "route-1"})
-    assert edge.trajectory is None
+    route_segment = RouteSegment(**{"routeId": "route-1"})
+    assert route_segment.trajectory is None
 
 
 def test_edge_trajectory_nurbs():
-    edge = Edge(
+    route_segment = RouteSegment(
         **{
             "routeId": "route-1",
             "trajectory": {
@@ -125,9 +125,9 @@ def test_edge_trajectory_nurbs():
             },
         }
     )
-    assert edge.trajectory.degree == 3
-    assert len(edge.trajectory.knotVector) == 6
-    assert len(edge.trajectory.controlPoints) == 3
+    assert route_segment.trajectory.degree == 3
+    assert len(route_segment.trajectory.knotVector) == 6
+    assert len(route_segment.trajectory.controlPoints) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -229,12 +229,12 @@ def test_mission_definition_with_route_segment_step():
 
 
 # ---------------------------------------------------------------------------
-# Edge — serialization round-trip
+# RouteSegment — serialization round-trip
 # ---------------------------------------------------------------------------
 
 
 def test_edge_model_dump_round_trip():
-    edge = Edge.model_validate(
+    route_segment = RouteSegment.model_validate(
         {
             "routeId": "route-AB",
             "trajectory": {
@@ -247,8 +247,8 @@ def test_edge_model_dump_round_trip():
         }
     )
 
-    dumped = edge.model_dump()
-    restored = Edge.model_validate(dumped)
+    dumped = route_segment.model_dump()
+    restored = route_segment.model_validate(dumped)
     assert restored.routeId == "route-AB"
     assert restored.corridor.width == 2.0
     assert restored.trajectory.degree == 3

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: 2024 InOrbit, Inc.
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import ValidationError
+
+from inorbit_edge_executor.datatypes import (
+    Edge,
+    EdgeCorridor,
+    EdgeTrajectory,
+    EdgeTrajectoryNurbsParameters,
+    MissionDefinition,
+    MissionStepPoseWaypoint,
+)
+
+
+# ---------------------------------------------------------------------------
+# EdgeCorridor
+# ---------------------------------------------------------------------------
+
+
+def test_edge_corridor_basic():
+    corridor = EdgeCorridor(width=2.0)
+    assert corridor.width == 2.0
+
+
+def test_edge_corridor_requires_width():
+    with pytest.raises(ValidationError):
+        EdgeCorridor()
+
+
+# ---------------------------------------------------------------------------
+# Edge — field presence and aliases
+# ---------------------------------------------------------------------------
+
+
+def test_edge_all_fields_from_js_resolver():
+    """Full edge object as produced by the JS EdgeExecutor resolver."""
+    edge = Edge(
+        **{
+            "edgeId": "e-AB",
+            "startWaypointId": "A",
+            "endWaypointId": "B",
+            "bidirectional": True,
+            "trajectory": {"type": "line"},
+            "corridor": {"width": 2.0},
+            "properties": {"edge": {"maxSpeed": "2"}},
+        }
+    )
+    assert edge.edge_id == "e-AB"
+    assert edge.start_waypoint_id == "A"
+    assert edge.end_waypoint_id == "B"
+    assert edge.bidirectional is True
+    assert edge.trajectory.type == "line"
+    assert edge.corridor.width == 2.0
+    assert edge.properties == {"edge": {"maxSpeed": "2"}}
+
+
+def test_edge_all_fields_optional():
+    """Edge with no fields set is valid."""
+    edge = Edge()
+    assert edge.edge_id is None
+    assert edge.start_waypoint_id is None
+    assert edge.end_waypoint_id is None
+    assert edge.bidirectional is None
+    assert edge.trajectory is None
+    assert edge.corridor is None
+    assert edge.properties is None
+
+
+def test_edge_partial_fields():
+    edge = Edge(**{"edgeId": "e-XY", "bidirectional": False})
+    assert edge.edge_id == "e-XY"
+    assert edge.bidirectional is False
+    assert edge.trajectory is None
+    assert edge.corridor is None
+
+
+# ---------------------------------------------------------------------------
+# Edge — properties shape (Issue 2)
+# ---------------------------------------------------------------------------
+
+
+def test_edge_properties_nested_dict():
+    """properties is Dict[str, Dict[str, Optional[str]]] — nested structure from annotation schema."""
+    edge = Edge(
+        **{
+            "properties": {
+                "edge": {"maxSpeed": "2", "someOtherProp": "value", "nullableProp": None}
+            }
+        }
+    )
+    assert edge.properties["edge"]["maxSpeed"] == "2"
+    assert edge.properties["edge"]["someOtherProp"] == "value"
+    assert edge.properties["edge"]["nullableProp"] is None
+
+
+def test_edge_properties_multiple_namespaces():
+    edge = Edge(
+        **{
+            "properties": {
+                "edge": {"maxSpeed": "2"},
+                "node": {"someFlag": "true"},
+            }
+        }
+    )
+    assert edge.properties["edge"]["maxSpeed"] == "2"
+    assert edge.properties["node"]["someFlag"] == "true"
+
+
+def test_edge_properties_flat_dict_is_invalid():
+    """A flat Dict[str, str] was the old (broken) shape — it must now be rejected."""
+    with pytest.raises(ValidationError):
+        Edge(**{"properties": {"maxSpeed": "2"}})
+
+
+# ---------------------------------------------------------------------------
+# Edge — trajectory variants
+# ---------------------------------------------------------------------------
+
+
+def test_edge_trajectory_line():
+    edge = Edge(**{"trajectory": {"type": "line"}})
+    assert edge.trajectory.type == "line"
+    assert edge.trajectory.parameters is None
+
+
+def test_edge_trajectory_nurbs():
+    edge = Edge(
+        **{
+            "trajectory": {
+                "type": "nurbs",
+                "parameters": {
+                    "degree": 3,
+                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    "controlPoints": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.5}, {"x": 2.0, "y": 0.0}],
+                },
+            }
+        }
+    )
+    assert edge.trajectory.type == "nurbs"
+    assert edge.trajectory.parameters.degree == 3
+    assert len(edge.trajectory.parameters.knotVector) == 6
+    assert len(edge.trajectory.parameters.controlPoints) == 3
+
+
+def test_edge_trajectory_nurbs_missing_parameters_is_invalid():
+    with pytest.raises(ValidationError):
+        Edge(**{"trajectory": {"type": "nurbs"}})
+
+
+def test_edge_trajectory_line_with_parameters_is_invalid():
+    with pytest.raises(ValidationError):
+        Edge(
+            **{
+                "trajectory": {
+                    "type": "line",
+                    "parameters": {
+                        "degree": 3,
+                        "knotVector": [0.0, 1.0],
+                        "controlPoints": [{"x": 0.0, "y": 0.0}],
+                    },
+                }
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# MissionStepPoseWaypoint with a full edge
+# ---------------------------------------------------------------------------
+
+
+def test_mission_step_pose_waypoint_with_full_edge():
+    """End-to-end: step as received after JS EdgeExecutor resolution."""
+    step = MissionStepPoseWaypoint(
+        **{
+            "waypoint": {
+                "x": 1.0,
+                "y": 2.0,
+                "theta": 0.0,
+                "frameId": "map",
+                "waypointId": "A",
+            },
+            "edge": {
+                "edgeId": "e-AB",
+                "startWaypointId": "A",
+                "endWaypointId": "B",
+                "bidirectional": True,
+                "trajectory": {"type": "line"},
+                "corridor": {"width": 1.5},
+                "properties": {"edge": {"maxSpeed": "1.5"}},
+            },
+        }
+    )
+    assert step.edge.edge_id == "e-AB"
+    assert step.edge.start_waypoint_id == "A"
+    assert step.edge.end_waypoint_id == "B"
+    assert step.edge.bidirectional is True
+    assert step.edge.trajectory.type == "line"
+    assert step.edge.corridor.width == 1.5
+    assert step.edge.properties["edge"]["maxSpeed"] == "1.5"
+
+
+def test_mission_step_pose_waypoint_without_edge():
+    step = MissionStepPoseWaypoint(
+        **{
+            "waypoint": {
+                "x": 0.0,
+                "y": 0.0,
+                "theta": 0.0,
+                "frameId": "map",
+                "waypointId": "A",
+            }
+        }
+    )
+    assert step.edge is None
+
+
+# ---------------------------------------------------------------------------
+# MissionDefinition round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_mission_definition_with_edge_step():
+    definition = MissionDefinition(
+        label="Test mission",
+        steps=[
+            {
+                "waypoint": {
+                    "x": 0.0,
+                    "y": 0.0,
+                    "theta": 0.0,
+                    "frameId": "map",
+                    "waypointId": "start",
+                },
+                "label": "Start",
+            },
+            {
+                "waypoint": {
+                    "x": 5.0,
+                    "y": 5.0,
+                    "theta": 1.57,
+                    "frameId": "map",
+                    "waypointId": "end",
+                },
+                "edge": {
+                    "edgeId": "e-start-end",
+                    "startWaypointId": "start",
+                    "endWaypointId": "end",
+                    "bidirectional": False,
+                    "trajectory": {"type": "line"},
+                    "corridor": {"width": 2.0},
+                    "properties": {"edge": {"maxSpeed": "2"}},
+                },
+                "label": "End",
+            },
+        ],
+    )
+    assert len(definition.steps) == 2
+    first, second = definition.steps
+    assert isinstance(first, MissionStepPoseWaypoint)
+    assert first.edge is None
+    assert isinstance(second, MissionStepPoseWaypoint)
+    assert second.edge.edge_id == "e-start-end"
+    assert second.edge.corridor.width == 2.0

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -134,7 +134,11 @@ def test_edge_trajectory_nurbs():
                 "parameters": {
                     "degree": 3,
                     "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                    "controlPoints": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 0.5}, {"x": 2.0, "y": 0.0}],
+                    "controlPoints": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.5},
+                        {"x": 2.0, "y": 0.0},
+                    ],
                 },
             }
         }

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -8,7 +8,6 @@ from pydantic import ValidationError
 from inorbit_edge_executor.datatypes import (
     Edge,
     EdgeCorridor,
-    EdgeTrajectory,
     EdgeTrajectoryNurbsParameters,
     MissionDefinition,
     MissionStepPoseWaypoint,
@@ -30,152 +29,113 @@ def test_edge_corridor_requires_width():
 
 
 # ---------------------------------------------------------------------------
-# Edge — field presence and aliases
+# Edge — field presence
 # ---------------------------------------------------------------------------
 
 
-def test_edge_all_fields_from_js_resolver():
-    """Full edge object as produced by the JS EdgeExecutor resolver."""
+def test_edge_all_fields():
     edge = Edge(
         **{
-            "edgeId": "e-AB",
-            "startWaypointId": "A",
-            "endWaypointId": "B",
-            "bidirectional": True,
-            "trajectory": {"type": "line"},
+            "routeId": "route-AB",
+            "trajectory": {
+                "degree": 3,
+                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                "controlPoints": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 1.0, "y": 0.5},
+                    {"x": 2.0, "y": 0.0},
+                ],
+            },
             "corridor": {"width": 2.0},
-            "properties": {"edge": {"maxSpeed": "2"}},
+            "properties": {"routeSegment": {"maxSpeed": "2"}},
         }
     )
-    assert edge.edge_id == "e-AB"
-    assert edge.start_waypoint_id == "A"
-    assert edge.end_waypoint_id == "B"
-    assert edge.bidirectional is True
-    assert edge.trajectory.type == "line"
+    assert edge.routeId == "route-AB"
+    assert edge.trajectory.degree == 3
     assert edge.corridor.width == 2.0
-    assert edge.properties == {"edge": {"maxSpeed": "2"}}
+    assert edge.properties == {"routeSegment": {"maxSpeed": "2"}}
 
 
-def test_edge_all_fields_optional():
-    """Edge with no fields set is valid."""
-    edge = Edge()
-    assert edge.edge_id is None
-    assert edge.start_waypoint_id is None
-    assert edge.end_waypoint_id is None
-    assert edge.bidirectional is None
+def test_edge_optional_fields_default_to_none():
+    edge = Edge(routeId="route-1")
     assert edge.trajectory is None
     assert edge.corridor is None
     assert edge.properties is None
 
 
 def test_edge_partial_fields():
-    edge = Edge(**{"edgeId": "e-XY", "bidirectional": False})
-    assert edge.edge_id == "e-XY"
-    assert edge.bidirectional is False
+    edge = Edge(**{"routeId": "route-XY", "corridor": {"width": 1.5}})
+    assert edge.routeId == "route-XY"
+    assert edge.corridor.width == 1.5
     assert edge.trajectory is None
-    assert edge.corridor is None
+    assert edge.properties is None
+
+
+def test_edge_requires_route_id():
+    with pytest.raises(ValidationError):
+        Edge()
 
 
 # ---------------------------------------------------------------------------
-# Edge — properties shape (Issue 2)
+# Edge — properties shape
 # ---------------------------------------------------------------------------
 
 
 def test_edge_properties_nested_dict():
-    """properties is Dict[str, Dict[str, Optional[str]]] — nested structure from annotation schema."""
     edge = Edge(
         **{
+            "routeId": "route-1",
             "properties": {
-                "edge": {"maxSpeed": "2", "someOtherProp": "value", "nullableProp": None}
-            }
+                "routeSegment": {"maxSpeed": "2", "someOtherProp": "value", "nullableProp": None}
+            },
         }
     )
-    assert edge.properties["edge"]["maxSpeed"] == "2"
-    assert edge.properties["edge"]["someOtherProp"] == "value"
-    assert edge.properties["edge"]["nullableProp"] is None
-
-
-def test_edge_properties_multiple_namespaces():
-    edge = Edge(
-        **{
-            "properties": {
-                "edge": {"maxSpeed": "2"},
-                "node": {"someFlag": "true"},
-            }
-        }
-    )
-    assert edge.properties["edge"]["maxSpeed"] == "2"
-    assert edge.properties["node"]["someFlag"] == "true"
+    assert edge.properties["routeSegment"]["maxSpeed"] == "2"
+    assert edge.properties["routeSegment"]["someOtherProp"] == "value"
+    assert edge.properties["routeSegment"]["nullableProp"] is None
 
 
 def test_edge_properties_flat_dict_is_invalid():
-    """A flat Dict[str, str] was the old (broken) shape — it must now be rejected."""
     with pytest.raises(ValidationError):
-        Edge(**{"properties": {"maxSpeed": "2"}})
+        Edge(**{"routeId": "route-1", "properties": {"maxSpeed": "2"}})
 
 
 # ---------------------------------------------------------------------------
-# Edge — trajectory variants
+# Edge — trajectory
 # ---------------------------------------------------------------------------
 
 
-def test_edge_trajectory_line():
-    edge = Edge(**{"trajectory": {"type": "line"}})
-    assert edge.trajectory.type == "line"
-    assert edge.trajectory.parameters is None
+def test_edge_trajectory_null_means_straight_line():
+    edge = Edge(**{"routeId": "route-1"})
+    assert edge.trajectory is None
 
 
 def test_edge_trajectory_nurbs():
     edge = Edge(
         **{
+            "routeId": "route-1",
             "trajectory": {
-                "type": "nurbs",
-                "parameters": {
-                    "degree": 3,
-                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                    "controlPoints": [
-                        {"x": 0.0, "y": 0.0},
-                        {"x": 1.0, "y": 0.5},
-                        {"x": 2.0, "y": 0.0},
-                    ],
-                },
-            }
+                "degree": 3,
+                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                "controlPoints": [
+                    {"x": 0.0, "y": 0.0},
+                    {"x": 1.0, "y": 0.5},
+                    {"x": 2.0, "y": 0.0},
+                ],
+            },
         }
     )
-    assert edge.trajectory.type == "nurbs"
-    assert edge.trajectory.parameters.degree == 3
-    assert len(edge.trajectory.parameters.knotVector) == 6
-    assert len(edge.trajectory.parameters.controlPoints) == 3
-
-
-def test_edge_trajectory_nurbs_missing_parameters_is_invalid():
-    with pytest.raises(ValidationError):
-        Edge(**{"trajectory": {"type": "nurbs"}})
-
-
-def test_edge_trajectory_line_with_parameters_is_invalid():
-    with pytest.raises(ValidationError):
-        Edge(
-            **{
-                "trajectory": {
-                    "type": "line",
-                    "parameters": {
-                        "degree": 3,
-                        "knotVector": [0.0, 1.0],
-                        "controlPoints": [{"x": 0.0, "y": 0.0}],
-                    },
-                }
-            }
-        )
+    assert edge.trajectory.degree == 3
+    assert len(edge.trajectory.knotVector) == 6
+    assert len(edge.trajectory.controlPoints) == 3
 
 
 # ---------------------------------------------------------------------------
-# MissionStepPoseWaypoint with a full edge
+# MissionStepPoseWaypoint with routeSegment
 # ---------------------------------------------------------------------------
 
 
-def test_mission_step_pose_waypoint_with_full_edge():
-    """End-to-end: step as received after JS EdgeExecutor resolution."""
+def test_mission_step_pose_waypoint_with_full_route_segment():
     step = MissionStepPoseWaypoint(
         **{
             "waypoint": {
@@ -186,26 +146,28 @@ def test_mission_step_pose_waypoint_with_full_edge():
                 "waypointId": "A",
             },
             "routeSegment": {
-                "edgeId": "e-AB",
-                "startWaypointId": "A",
-                "endWaypointId": "B",
-                "bidirectional": True,
-                "trajectory": {"type": "line"},
+                "routeId": "route-AB",
+                "trajectory": {
+                    "degree": 3,
+                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    "controlPoints": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.5},
+                        {"x": 2.0, "y": 0.0},
+                    ],
+                },
                 "corridor": {"width": 1.5},
                 "properties": {"routeSegment": {"maxSpeed": "1.5"}},
             },
         }
     )
-    assert step.routeSegment.edge_id == "e-AB"
-    assert step.routeSegment.start_waypoint_id == "A"
-    assert step.routeSegment.end_waypoint_id == "B"
-    assert step.routeSegment.bidirectional is True
-    assert step.routeSegment.trajectory.type == "line"
+    assert step.routeSegment.routeId == "route-AB"
+    assert step.routeSegment.trajectory.degree == 3
     assert step.routeSegment.corridor.width == 1.5
     assert step.routeSegment.properties["routeSegment"]["maxSpeed"] == "1.5"
 
 
-def test_mission_step_pose_waypoint_without_edge():
+def test_mission_step_pose_waypoint_without_route_segment():
     step = MissionStepPoseWaypoint(
         **{
             "waypoint": {
@@ -225,7 +187,7 @@ def test_mission_step_pose_waypoint_without_edge():
 # ---------------------------------------------------------------------------
 
 
-def test_mission_definition_with_edge_step():
+def test_mission_definition_with_route_segment_step():
     definition = MissionDefinition(
         label="Test mission",
         steps=[
@@ -248,11 +210,8 @@ def test_mission_definition_with_edge_step():
                     "waypointId": "end",
                 },
                 "routeSegment": {
-                    "edgeId": "e-start-end",
-                    "startWaypointId": "start",
-                    "endWaypointId": "end",
-                    "bidirectional": False,
-                    "trajectory": {"type": "line"},
+                    "routeId": "route-start-end",
+                    "trajectory": None,
                     "corridor": {"width": 2.0},
                     "properties": {"routeSegment": {"maxSpeed": "2"}},
                 },
@@ -265,38 +224,31 @@ def test_mission_definition_with_edge_step():
     assert isinstance(first, MissionStepPoseWaypoint)
     assert first.routeSegment is None
     assert isinstance(second, MissionStepPoseWaypoint)
-    assert second.routeSegment.edge_id == "e-start-end"
+    assert second.routeSegment.routeId == "route-start-end"
     assert second.routeSegment.corridor.width == 2.0
 
 
 # ---------------------------------------------------------------------------
-# Edge — serialization (model_dump by_alias)
+# Edge — serialization round-trip
 # ---------------------------------------------------------------------------
 
 
-def test_edge_model_dump_uses_aliases():
-    """model_dump(by_alias=True) must produce JS-style camelCase keys so that
-    Edge.model_validate() can round-trip through the serialized dict."""
+def test_edge_model_dump_round_trip():
     edge = Edge.model_validate(
         {
-            "edgeId": "e-AB",
-            "startWaypointId": "A",
-            "endWaypointId": "B",
-            "bidirectional": True,
-            "trajectory": {"type": "line"},
+            "routeId": "route-AB",
+            "trajectory": {
+                "degree": 3,
+                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                "controlPoints": [{"x": 0.0, "y": 0.0}, {"x": 2.0, "y": 0.0}],
+            },
             "corridor": {"width": 2.0},
-            "properties": {"edge": {"maxSpeed": "2"}},
+            "properties": {"routeSegment": {"maxSpeed": "2"}},
         }
     )
 
-    dumped = edge.model_dump(by_alias=True)
-    assert dumped["edgeId"] == "e-AB"
-    assert dumped["startWaypointId"] == "A"
-    assert dumped["endWaypointId"] == "B"
-    assert dumped["corridor"]["width"] == 2.0
-
-    # Round-trip: the serialized dict must be re-parseable
+    dumped = edge.model_dump()
     restored = Edge.model_validate(dumped)
-    assert restored.edge_id == "e-AB"
+    assert restored.routeId == "route-AB"
     assert restored.corridor.width == 2.0
-    assert restored.properties["edge"]["maxSpeed"] == "2"
+    assert restored.trajectory.degree == 3

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -247,14 +247,14 @@ def test_mission_definition_with_edge_step():
                     "frameId": "map",
                     "waypointId": "end",
                 },
-                "edge": {
+                "routeSegment": {
                     "edgeId": "e-start-end",
                     "startWaypointId": "start",
                     "endWaypointId": "end",
                     "bidirectional": False,
                     "trajectory": {"type": "line"},
                     "corridor": {"width": 2.0},
-                    "properties": {"edge": {"maxSpeed": "2"}},
+                    "properties": {"routeSegment": {"maxSpeed": "2"}},
                 },
                 "label": "End",
             },

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -61,20 +61,23 @@ def test_edge_all_fields():
         **{
             "routeId": "route-AB",
             "trajectory": {
-                "degree": 3,
-                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                "controlPoints": [
-                    {"x": 0.0, "y": 0.0},
-                    {"x": 1.0, "y": 0.5},
-                    {"x": 2.0, "y": 0.0},
-                ],
+                "type": "nurbs",
+                "parameters": {
+                    "degree": 3,
+                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    "controlPoints": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.5},
+                        {"x": 2.0, "y": 0.0},
+                    ],
+                },
             },
             "corridor": {"width": 2.0},
             "properties": {"routeSegment": {"maxSpeed": "2"}},
         }
     )
     assert route_segment.routeId == "route-AB"
-    assert route_segment.trajectory.degree == 3
+    assert route_segment.trajectory.parameters.degree == 3
     assert route_segment.corridor.width == 2.0
     assert route_segment.properties == {"routeSegment": {"maxSpeed": "2"}}
 
@@ -138,19 +141,27 @@ def test_edge_trajectory_nurbs():
         **{
             "routeId": "route-1",
             "trajectory": {
-                "degree": 3,
-                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                "controlPoints": [
-                    {"x": 0.0, "y": 0.0},
-                    {"x": 1.0, "y": 0.5},
-                    {"x": 2.0, "y": 0.0},
-                ],
+                "type": "nurbs",
+                "parameters": {
+                    "degree": 3,
+                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    "controlPoints": [
+                        {"x": 0.0, "y": 0.0},
+                        {"x": 1.0, "y": 0.5},
+                        {"x": 2.0, "y": 0.0},
+                    ],
+                },
             },
         }
     )
-    assert route_segment.trajectory.degree == 3
-    assert len(route_segment.trajectory.knotVector) == 6
-    assert len(route_segment.trajectory.controlPoints) == 3
+    assert route_segment.trajectory.parameters.degree == 3
+    assert len(route_segment.trajectory.parameters.knotVector) == 6
+    assert len(route_segment.trajectory.parameters.controlPoints) == 3
+
+
+def test_edge_trajectory_nurbs_without_parameters_fails():
+    with pytest.raises(ValidationError):
+        RouteSegment(**{"routeId": "route-1", "trajectory": {"type": "nurbs"}})
 
 
 # ---------------------------------------------------------------------------
@@ -171,13 +182,16 @@ def test_mission_step_pose_waypoint_with_full_route_segment():
             "routeSegment": {
                 "routeId": "route-AB",
                 "trajectory": {
-                    "degree": 3,
-                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                    "controlPoints": [
-                        {"x": 0.0, "y": 0.0},
-                        {"x": 1.0, "y": 0.5},
-                        {"x": 2.0, "y": 0.0},
-                    ],
+                    "type": "nurbs",
+                    "parameters": {
+                        "degree": 3,
+                        "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                        "controlPoints": [
+                            {"x": 0.0, "y": 0.0},
+                            {"x": 1.0, "y": 0.5},
+                            {"x": 2.0, "y": 0.0},
+                        ],
+                    },
                 },
                 "corridor": {"width": 1.5},
                 "properties": {"routeSegment": {"maxSpeed": "1.5"}},
@@ -185,7 +199,7 @@ def test_mission_step_pose_waypoint_with_full_route_segment():
         }
     )
     assert step.routeSegment.routeId == "route-AB"
-    assert step.routeSegment.trajectory.degree == 3
+    assert step.routeSegment.trajectory.parameters.degree == 3
     assert step.routeSegment.corridor.width == 1.5
     assert step.routeSegment.properties["routeSegment"]["maxSpeed"] == "1.5"
 
@@ -295,9 +309,12 @@ def test_edge_model_dump_round_trip():
         {
             "routeId": "route-AB",
             "trajectory": {
-                "degree": 3,
-                "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
-                "controlPoints": [{"x": 0.0, "y": 0.0}, {"x": 2.0, "y": 0.0}],
+                "type": "nurbs",
+                "parameters": {
+                    "degree": 3,
+                    "knotVector": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+                    "controlPoints": [{"x": 0.0, "y": 0.0}, {"x": 2.0, "y": 0.0}],
+                },
             },
             "corridor": {"width": 2.0},
             "properties": {"routeSegment": {"maxSpeed": "2"}},
@@ -308,4 +325,4 @@ def test_edge_model_dump_round_trip():
     restored = route_segment.model_validate(dumped)
     assert restored.routeId == "route-AB"
     assert restored.corridor.width == 2.0
-    assert restored.trajectory.degree == 3
+    assert restored.trajectory.parameters.degree == 3

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -185,24 +185,24 @@ def test_mission_step_pose_waypoint_with_full_edge():
                 "frameId": "map",
                 "waypointId": "A",
             },
-            "edge": {
+            "routeSegment": {
                 "edgeId": "e-AB",
                 "startWaypointId": "A",
                 "endWaypointId": "B",
                 "bidirectional": True,
                 "trajectory": {"type": "line"},
                 "corridor": {"width": 1.5},
-                "properties": {"edge": {"maxSpeed": "1.5"}},
+                "properties": {"routeSegment": {"maxSpeed": "1.5"}},
             },
         }
     )
-    assert step.edge.edge_id == "e-AB"
-    assert step.edge.start_waypoint_id == "A"
-    assert step.edge.end_waypoint_id == "B"
-    assert step.edge.bidirectional is True
-    assert step.edge.trajectory.type == "line"
-    assert step.edge.corridor.width == 1.5
-    assert step.edge.properties["edge"]["maxSpeed"] == "1.5"
+    assert step.routeSegment.edge_id == "e-AB"
+    assert step.routeSegment.start_waypoint_id == "A"
+    assert step.routeSegment.end_waypoint_id == "B"
+    assert step.routeSegment.bidirectional is True
+    assert step.routeSegment.trajectory.type == "line"
+    assert step.routeSegment.corridor.width == 1.5
+    assert step.routeSegment.properties["routeSegment"]["maxSpeed"] == "1.5"
 
 
 def test_mission_step_pose_waypoint_without_edge():
@@ -217,7 +217,7 @@ def test_mission_step_pose_waypoint_without_edge():
             }
         }
     )
-    assert step.edge is None
+    assert step.routeSegment is None
 
 
 # ---------------------------------------------------------------------------
@@ -263,10 +263,10 @@ def test_mission_definition_with_edge_step():
     assert len(definition.steps) == 2
     first, second = definition.steps
     assert isinstance(first, MissionStepPoseWaypoint)
-    assert first.edge is None
+    assert first.routeSegment is None
     assert isinstance(second, MissionStepPoseWaypoint)
-    assert second.edge.edge_id == "e-start-end"
-    assert second.edge.corridor.width == 2.0
+    assert second.routeSegment.edge_id == "e-start-end"
+    assert second.routeSegment.corridor.width == 2.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -28,6 +28,28 @@ def test_edge_corridor_requires_width():
         RouteSegmentCorridor()
 
 
+def test_edge_corridor_asymmetric():
+    corridor = RouteSegmentCorridor(leftWidth=1.0, rightWidth=0.5)
+    assert corridor.leftWidth == 1.0
+    assert corridor.rightWidth == 0.5
+    assert corridor.width is None
+
+
+def test_edge_corridor_left_without_right_fails():
+    with pytest.raises(ValidationError):
+        RouteSegmentCorridor(leftWidth=1.0)
+
+
+def test_edge_corridor_right_without_left_fails():
+    with pytest.raises(ValidationError):
+        RouteSegmentCorridor(rightWidth=1.0)
+
+
+def test_edge_corridor_asymmetric_with_symmetric_fails():
+    with pytest.raises(ValidationError):
+        RouteSegmentCorridor(width=1.0, leftWidth=0.5, rightWidth=0.5)
+
+
 # ---------------------------------------------------------------------------
 # RouteSegment — field presence
 # ---------------------------------------------------------------------------

--- a/tests/test_edge_datatype.py
+++ b/tests/test_edge_datatype.py
@@ -14,7 +14,6 @@ from inorbit_edge_executor.datatypes import (
     MissionStepPoseWaypoint,
 )
 
-
 # ---------------------------------------------------------------------------
 # EdgeCorridor
 # ---------------------------------------------------------------------------
@@ -268,3 +267,36 @@ def test_mission_definition_with_edge_step():
     assert isinstance(second, MissionStepPoseWaypoint)
     assert second.edge.edge_id == "e-start-end"
     assert second.edge.corridor.width == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Edge — serialization (model_dump by_alias)
+# ---------------------------------------------------------------------------
+
+
+def test_edge_model_dump_uses_aliases():
+    """model_dump(by_alias=True) must produce JS-style camelCase keys so that
+    Edge.model_validate() can round-trip through the serialized dict."""
+    edge = Edge.model_validate(
+        {
+            "edgeId": "e-AB",
+            "startWaypointId": "A",
+            "endWaypointId": "B",
+            "bidirectional": True,
+            "trajectory": {"type": "line"},
+            "corridor": {"width": 2.0},
+            "properties": {"edge": {"maxSpeed": "2"}},
+        }
+    )
+
+    dumped = edge.model_dump(by_alias=True)
+    assert dumped["edgeId"] == "e-AB"
+    assert dumped["startWaypointId"] == "A"
+    assert dumped["endWaypointId"] == "B"
+    assert dumped["corridor"]["width"] == 2.0
+
+    # Round-trip: the serialized dict must be re-parseable
+    restored = Edge.model_validate(dumped)
+    assert restored.edge_id == "e-AB"
+    assert restored.corridor.width == 2.0
+    assert restored.properties["edge"]["maxSpeed"] == "2"


### PR DESCRIPTION
## Summary
Updating the executor to match the mission dispatch format used by graph-based fleet managers, which includes route segment metadata (route ID, trajectory, corridor geometry) alongside waypoint coordinates.

- Adds RouteSegment data types to the schema, including corridor geometry with support for symmetric and asymmetric widths, validated at parse time — Respective tests included
- Adds RouteSegmentTrajectory type with type and parameters fields; validates that parameters are required when type is nurbs, and absent for straight-line segments — Respective tests included
- Makes Pose.theta optional; waypoints without a target heading no longer require an angular tolerance check to complete — Respective tests included
- Extends MissionStepPoseWaypoint to accept an optional routeSegment field and forwards it to the navigation action arguments when present, with no change to default behavior — Respective tests included
- Introduces a translate_step() hook in WorkerPool so connector implementations can transform individual steps without overriding the full mission translation loop — Respective tests included
- Adds planner field to MissionDefinition for backward compatibility with missions dispatched with graph planner configuration — Respective tests included
