### PR TITLE
Default null waypoint theta to 0 in the navigation command

### DIFF
--- a/inorbit_edge_executor/behavior_tree.py
+++ b/inorbit_edge_executor/behavior_tree.py
@@ -1147,11 +1147,18 @@ class NodeFromStepBuilder:
 
     def visit_pose_waypoint(self, step: MissionStepPoseWaypoint):
         waypoint = step.waypoint
+        # InOrbit allows for heading-less waypoint goals, which may be interpreted by integrations
+        # that override this behavior.
+        # When interpreting a pose waypoint using the waypoint navigation action, default
+        # the theta value to 0.
+        # The arrival check below stays keyed off the original waypoint.theta, so a null theta
+        # still skips the angular check and the waypoint is reached on position alone.
+        pose_theta = waypoint.theta if waypoint.theta is not None else 0.0
         arguments = dict(
             pose=dict(
                 x=waypoint.x,
                 y=waypoint.y,
-                theta=waypoint.theta,
+                theta=pose_theta,
                 frameId=waypoint.frame_id,
             ),
             **({"routeSegment": step.routeSegment.model_dump()} if step.routeSegment else {}),

--- a/tests/test_behavior_tree.py
+++ b/tests/test_behavior_tree.py
@@ -399,6 +399,16 @@ def test_visit_pose_waypoint_theta_none_skips_angular_distance():
     assert "angularDistance" not in wait_node["expression"]
 
 
+def test_visit_pose_waypoint_theta_none_defaults_command_to_zero():
+    run_node, wait_node = _build_waypoint_nodes(
+        {"waypoint": {"x": 1.0, "y": 2.0, "frameId": "map"}}
+    )
+    # Free-planner robots reject a null orientation, so the navigation command defaults to 0.0,
+    # while the arrival check stays orientation-agnostic (no angular distance check).
+    assert run_node["arguments"]["pose"]["theta"] == 0.0
+    assert "angularDistance" not in wait_node["expression"]
+
+
 def test_visit_pose_waypoint_theta_set_includes_angular_distance():
     _, wait_node = _build_waypoint_nodes(
         {"waypoint": {"x": 1.0, "y": 2.0, "theta": 1.57, "frameId": "map"}}


### PR DESCRIPTION
## Summary

Waypoint spatial annotations can now omit `theta` (orientation). Robots that free-plan to a pose (e.g. the ROS2 agent, default Connect SDK behavior) cannot accept a null orientation: a `NavigateTo` command with a null theta produces an empty-theta nav goal that crashes them.

This defaults a missing `theta` to `0.0` in the navigation command pose built by `NodeFromStepBuilder.visit_pose_waypoint`.

## What changed

- `visit_pose_waypoint` now sends `theta=0.0` in the `NavigateTo` command pose when the waypoint's `theta` is `None` (was passing `None` through).
- The waypoint **arrival check is unchanged**: it still keys off the original `waypoint.theta`, so a null theta keeps skipping the angular-distance check (the waypoint is reached on position alone). No new orientation wait is introduced for headingless waypoints.

- The angular-tolerance/skip behavior for null theta already exists (added in 4.0.2); this only fills in the command pose value.
- Integrations that override `visit_pose_waypoint` are unaffected. For example the `vda5050-connector` uses its own tree builder (`Vda5050TreeBuilder` / `Vda5050PublishOrderNode`), never calls `visit_pose_waypoint`, and already guards `if wp.theta is not None` when building VDA5050 node positions — so graph-planner connectors keep omitting theta as before.
