### PR TITLE
Fix double slash in InOrbitAPI request URLs

### DIFF
--- a/inorbit_edge_executor/inorbit.py
+++ b/inorbit_edge_executor/inorbit.py
@@ -137,7 +137,7 @@ class InOrbitAPI:
 
     def __init__(self, base_url="https://api.inorbit.ai", api_key=None, peer_key=None):
         logger.info("InOrbit API: " + base_url)
-        self._base_url = base_url
+        self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._peer_key = peer_key
 

--- a/tests/test_inorbit_api.py
+++ b/tests/test_inorbit_api.py
@@ -1,0 +1,28 @@
+import pytest
+import httpx
+from pytest_httpx import HTTPXMock
+from inorbit_edge_executor.inorbit import InOrbitAPI
+
+
+def test_base_url_trailing_slash_stripped():
+    """A trailing slash (as produced by str(pydantic.HttpUrl)) must not be kept."""
+    assert InOrbitAPI(base_url="https://api.inorbit.ai/")._base_url == "https://api.inorbit.ai"
+    assert InOrbitAPI(base_url="https://api.inorbit.ai")._base_url == "https://api.inorbit.ai"
+
+
+@pytest.mark.asyncio
+async def test_request_url_has_no_double_slash(httpx_mock: HTTPXMock):
+    """Joining base_url + path must not produce '//' even with a trailing-slash base_url."""
+    captured = {}
+
+    def capture(request: httpx.Request):
+        captured["url"] = str(request.url)
+        return httpx.Response(status_code=200, json={})
+
+    httpx_mock.add_callback(capture, is_reusable=True)
+
+    api = InOrbitAPI(base_url="https://api.inorbit.ai/", api_key="secret")
+    await api.post("robots/door-rs-1/actions", {"actionId": "open"})
+
+    assert captured["url"] == "https://api.inorbit.ai/robots/door-rs-1/actions"
+    assert "//robots" not in captured["url"]


### PR DESCRIPTION
## Problem

`InOrbitAPI` builds every request as `f"{base_url}/{path}"`. When `base_url` has a trailing slash, the joined URL gets a double slash (`//`), which the InOrbit API rejects.

In practice this happens whenever the base URL comes from a pydantic `HttpUrl`: `str(HttpUrl("https://api.inorbit.ai"))` → `"https://api.inorbit.ai/"`. The resulting requests hit e.g. `https://api.inorbit.ai//robots/<id>/actions` and come back as `NOT_FOUND`.

Observed downstream in the MiR Fleet connector: a `runAction` mission step failed with `Error executing action: NOT_FOUND` after the connector switched its base URL source to `str(config.api_url)`. Mission-tracking calls (`//missions/...`) were silently 404ing for the same reason.

## Fix

Strip trailing slashes from `base_url` in `InOrbitAPI.__init__`. All `build_*_api_path()` helpers return paths with no leading slash, so normalizing the base is sufficient and the join is correct regardless of how the caller supplies the URL.

## Testing

Added `tests/test_inorbit_api.py`:
- `base_url` with a trailing slash is normalized.
- A real request through `httpx` (via `pytest_httpx`) produces no `//` in the path.